### PR TITLE
fix naming in gwpop redshift model and PL spline redshift

### DIFF
--- a/gwinferno/models/gwpopulation/gwpopulation.py
+++ b/gwinferno/models/gwpopulation/gwpopulation.py
@@ -96,32 +96,32 @@ class PowerlawRedshiftModel(object):
         self.zmin = jnp.max(jnp.array([jnp.min(z_pe), jnp.min(z_inj)]))
         self.zmax = jnp.min(jnp.array([jnp.max(z_pe), jnp.max(z_inj)]))
         self.zs = jnp.linspace(self.zmin, self.zmax, 1000)
-        self.dVdc_ = jnp.array(Planck15.differential_comoving_volume(np.array(self.zs)).value * 4.0 * np.pi)
-        self.dVdcs = [
+        self.dVdz_ = jnp.array(Planck15.differential_comoving_volume(np.array(self.zs)).value * 4.0 * np.pi)
+        self.dVdzs = [
             jnp.array(Planck15.differential_comoving_volume(np.array(z_inj)).value * 4.0 * np.pi),
             jnp.array(Planck15.differential_comoving_volume(np.array(z_pe)).value * 4.0 * np.pi),
         ]
 
     def normalization(self, lamb):
-        return jnp.trapz(self.prob(self.zs, self.dVdc_, lamb), self.zs)
+        return jnp.trapz(self.prob(self.zs, self.dVdz_, lamb), self.zs)
 
-    def prob(self, z, dVdc, lamb):
-        return dVdc * jnp.power(1.0 + z, lamb - 1.0)
+    def prob(self, z, dVdz, lamb):
+        return dVdz * jnp.power(1.0 + z, lamb - 1.0)
 
     def log_prob(self, z, lamb):
         ndim = len(z.shape)
-        dVdc = self.dVdcs[ndim - 1]
+        dVdz = self.dVdzs[ndim - 1]
         return jnp.where(
             jnp.less_equal(z, self.zmax),
-            jnp.log(dVdc) + (lamb - 1.0) * jnp.log(1.0 + z) - jnp.log(self.normalization(lamb)),
+            jnp.log(dVdz) + (lamb - 1.0) * jnp.log(1.0 + z) - jnp.log(self.normalization(lamb)),
             jnp.nan_to_num(-jnp.inf),
         )
 
     def __call__(self, z, lamb):
         ndim = len(z.shape)
-        dVdc = self.dVdcs[ndim - 1]
+        dVdz = self.dVdzs[ndim - 1]
         return jnp.where(
             jnp.less_equal(z, self.zmax),
-            self.prob(z, dVdc, lamb) / self.normalization(lamb),
+            self.prob(z, dVdz, lamb) / self.normalization(lamb),
             0,
         )

--- a/gwinferno/models/spline_perturbation.py
+++ b/gwinferno/models/spline_perturbation.py
@@ -328,7 +328,7 @@ class PowerlawSplineRedshiftModel(PowerlawRedshiftModel):
         Returns:
             _type_:
         """
-        pz = self.dVdc_ * jnp.power(1.0 + self.zs, lamb - 1)
+        pz = self.dVdz_ * jnp.power(1.0 + self.zs, lamb - 1)
         pz *= jnp.exp(self.interpolator.project(self.norm_design_matrix, cs))
         return jnp.trapz(pz, self.zs)
 
@@ -361,9 +361,9 @@ class PowerlawSplineRedshiftModel(PowerlawRedshiftModel):
             jnp.ndarray:
         """
         ndim = len(z.shape)
-        dV_cdz = self.dV_cdz[ndim - 1]
+        dVdz = self.dVdzs[ndim - 1]
         return jnp.where(
             jnp.less_equal(z, self.zmax),
-            self.prob(z, dV_cdz, lamb, cs) / self.normalization(lamb, cs),
+            self.prob(z, dVdz, lamb, cs) / self.normalization(lamb, cs),
             0,
         )


### PR DESCRIPTION
This fixes #50.  There were some names that didn't make sense in the gwpop models, and those weren't referenced properly in the spline perturbation model.  This should fix both.